### PR TITLE
Remove unused HEX_NEIGHBORS constant from hex.rs

### DIFF
--- a/cspuz_rs/src/hex.rs
+++ b/cspuz_rs/src/hex.rs
@@ -42,8 +42,6 @@ use std::ops::{Index, IndexMut};
 use crate::graph::Graph;
 use crate::solver::{BoolVar, FromModel, FromOwnedPartialModel, Model, Solver};
 
-const HEX_NEIGHBORS: [(i32, i32); 6] = [(-1, -1), (-1, 0), (0, -1), (0, 1), (1, 0), (1, 1)];
-
 #[derive(Clone, Debug)]
 struct HexCellMapping {
     a: usize,


### PR DESCRIPTION
Suppress the following warning:

```
warning: constant `HEX_NEIGHBORS` is never used
  --> cspuz_core/cspuz_rs/src/hex.rs:45:7
   |
45 | const HEX_NEIGHBORS: [(i32, i32); 6] = [(-1, -1), (-1, 0), (0, -1), (0, 1), (1, 0), (1, 1)];
   |       ^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```
