### PR TITLE
speedup large-scale nurikabe solving via new per-clue connectivity encoding

### DIFF
--- a/cspuz_rs_puzzles/src/puzzles/nurikabe.rs
+++ b/cspuz_rs_puzzles/src/puzzles/nurikabe.rs
@@ -3,16 +3,34 @@ use cspuz_rs::graph;
 use cspuz_rs::serializer::{
     problem_to_url, url_to_problem, Choice, Combinator, Dict, Grid, HexInt, Optionalize, Spaces,
 };
-use cspuz_rs::solver::{BoolVarArray2D, Solver};
+use cspuz_rs::solver::{count_true, BoolVarArray2D, Solver};
+
+/// `Reachable` is the default encoding. `GroupId` is kept for tests and local A/B.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NurikabeModel {
+    GroupId,
+    Reachable,
+}
+
+const DEFAULT_MODEL: NurikabeModel = NurikabeModel::Reachable;
 
 pub fn solve_nurikabe(clues: &[Vec<Option<i32>>]) -> Option<Vec<Vec<Option<bool>>>> {
+    solve_nurikabe_with_model(clues, DEFAULT_MODEL)
+}
+
+#[doc(hidden)]
+pub fn solve_nurikabe_with_model(
+    clues: &[Vec<Option<i32>>],
+    model: NurikabeModel,
+) -> Option<Vec<Vec<Option<bool>>>> {
     let (h, w) = util::infer_shape(clues);
 
     let mut solver = Solver::new();
     let is_black = &solver.bool_var_2d((h, w));
     solver.add_answer_key_bool(is_black);
 
-    add_constraints(clues, &mut solver, is_black);
+    add_constraints(clues, &mut solver, is_black, model);
 
     solver.irrefutable_facts().map(|f| f.get(is_black))
 }
@@ -21,13 +39,22 @@ pub fn enumerate_answers_nurikabe(
     clues: &[Vec<Option<i32>>],
     num_max_answers: usize,
 ) -> Vec<Vec<Vec<bool>>> {
+    enumerate_answers_nurikabe_with_model(clues, num_max_answers, DEFAULT_MODEL)
+}
+
+#[doc(hidden)]
+pub fn enumerate_answers_nurikabe_with_model(
+    clues: &[Vec<Option<i32>>],
+    num_max_answers: usize,
+    model: NurikabeModel,
+) -> Vec<Vec<Vec<bool>>> {
     let (h, w) = util::infer_shape(clues);
 
     let mut solver = Solver::new();
     let is_black = &solver.bool_var_2d((h, w));
     solver.add_answer_key_bool(is_black);
 
-    add_constraints(clues, &mut solver, is_black);
+    add_constraints(clues, &mut solver, is_black, model);
 
     solver
         .answer_iter()
@@ -36,7 +63,23 @@ pub fn enumerate_answers_nurikabe(
         .collect()
 }
 
-fn add_constraints(clues: &[Vec<Option<i32>>], solver: &mut Solver, is_black: &BoolVarArray2D) {
+fn add_constraints(
+    clues: &[Vec<Option<i32>>],
+    solver: &mut Solver,
+    is_black: &BoolVarArray2D,
+    model: NurikabeModel,
+) {
+    match model {
+        NurikabeModel::GroupId => add_constraints_group_id(clues, solver, is_black),
+        NurikabeModel::Reachable => add_constraints_reachable(clues, solver, is_black),
+    }
+}
+
+fn add_constraints_group_id(
+    clues: &[Vec<Option<i32>>],
+    solver: &mut Solver,
+    is_black: &BoolVarArray2D,
+) {
     let (h, w) = util::infer_shape(clues);
 
     let mut clue_pos = vec![];
@@ -80,6 +123,116 @@ fn add_constraints(clues: &[Vec<Option<i32>>], solver: &mut Solver, is_black: &B
     }
 }
 
+fn manhattan(a: (usize, usize), b: (usize, usize)) -> usize {
+    a.0.abs_diff(b.0) + a.1.abs_diff(b.1)
+}
+
+/// Cells that may belong to the island of clue `n` at `(y, x)`.
+/// Finite `n > 0` is the open Manhattan ball `dist < n`; unknown size (`n <= 0`) is the whole board.
+fn island_region(h: usize, w: usize, y: usize, x: usize, n: i32) -> Vec<(usize, usize)> {
+    let mut region = Vec::new();
+    for yy in 0..h {
+        for xx in 0..w {
+            if n <= 0 || manhattan((yy, xx), (y, x)) < n as usize {
+                region.push((yy, xx));
+            }
+        }
+    }
+    region
+}
+
+fn add_constraints_reachable(
+    clues: &[Vec<Option<i32>>],
+    solver: &mut Solver,
+    is_black: &BoolVarArray2D,
+) {
+    let (h, w) = util::infer_shape(clues);
+
+    let mut clue_pos = vec![];
+    for y in 0..h {
+        for x in 0..w {
+            if let Some(n) = clues[y][x] {
+                clue_pos.push((y, x, n));
+            }
+        }
+    }
+
+    graph::active_vertices_connected_2d(solver, is_black);
+    solver.add_expr(!is_black.conv2d_and((2, 2)));
+
+    let mut islands = Vec::with_capacity(clue_pos.len());
+    let mut regions = Vec::with_capacity(clue_pos.len());
+    let mut in_region = Vec::with_capacity(clue_pos.len());
+    for &(y, x, n) in &clue_pos {
+        islands.push(solver.bool_var_2d((h, w)));
+        let region = island_region(h, w, y, x, n);
+        let mut mask = vec![vec![false; w]; h];
+        for &(yy, xx) in &region {
+            mask[yy][xx] = true;
+        }
+        regions.push(region);
+        in_region.push(mask);
+    }
+
+    for i in 0..clue_pos.len() {
+        let island = &islands[i];
+        solver.add_expr(island.imp(!is_black));
+
+        for y in 0..h {
+            for x in 0..w {
+                if !in_region[i][y][x] {
+                    solver.add_expr(!island.at((y, x)));
+                }
+            }
+        }
+        graph::active_vertices_connected_2d_region(solver, island, &regions[i]);
+
+        let (y, x, n) = clue_pos[i];
+        solver.add_expr(island.at((y, x)));
+        for (j, &(yj, xj, _)) in clue_pos.iter().enumerate() {
+            if i != j {
+                solver.add_expr(!island.at((yj, xj)));
+            }
+        }
+        if n > 0 {
+            solver.add_expr(island.count_true().eq(n));
+        }
+
+        solver.add_expr(
+            (island.slice((..(h - 1), ..)) & !is_black.slice((1.., ..)))
+                .imp(island.slice((1.., ..))),
+        );
+        solver.add_expr(
+            (island.slice((1.., ..)) & !is_black.slice((..(h - 1), ..)))
+                .imp(island.slice((..(h - 1), ..))),
+        );
+        solver.add_expr(
+            (island.slice((.., ..(w - 1))) & !is_black.slice((.., 1..)))
+                .imp(island.slice((.., 1..))),
+        );
+        solver.add_expr(
+            (island.slice((.., 1..)) & !is_black.slice((.., ..(w - 1))))
+                .imp(island.slice((.., ..(w - 1)))),
+        );
+    }
+
+    for y in 0..h {
+        for x in 0..w {
+            let members: Vec<_> = islands
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| in_region[*i][y][x])
+                .map(|(_, island)| island.at((y, x)))
+                .collect();
+            if members.is_empty() {
+                solver.add_expr(is_black.at((y, x)));
+            } else {
+                solver.add_expr(count_true(members).eq(is_black.at((y, x)).ite(0, 1)));
+            }
+        }
+    }
+}
+
 type Problem = Vec<Vec<Option<i32>>>;
 
 fn combinator() -> impl Combinator<Problem> {
@@ -113,6 +266,13 @@ mod tests {
         ]
     }
 
+    fn answers_match(problem: &[Vec<Option<i32>>]) {
+        let group_id = enumerate_answers_nurikabe_with_model(problem, 3, NurikabeModel::GroupId);
+        let reachable = enumerate_answers_nurikabe_with_model(problem, 3, NurikabeModel::Reachable);
+        assert_eq!(group_id, reachable);
+        assert_eq!(group_id.len(), 1);
+    }
+
     #[test]
     #[rustfmt::skip]
     fn test_nurikabe_problem() {
@@ -130,6 +290,26 @@ mod tests {
             vec![Some(false), None, Some(false), None, Some(false), Some(false)],
         ];
         assert_eq!(ans, expected);
+        assert_eq!(
+            solve_nurikabe_with_model(&problem, NurikabeModel::GroupId),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn test_nurikabe_encodings_agree() {
+        answers_match(&[
+            vec![Some(1), None, Some(1)],
+            vec![None, None, None],
+            vec![Some(1), None, Some(1)],
+        ]);
+        answers_match(&[
+            vec![Some(-1), None, Some(1)],
+            vec![None, None, None],
+            vec![Some(1), None, Some(1)],
+        ]);
+        assert_eq!(island_region(4, 4, 0, 0, 2).len(), 3);
+        assert_eq!(island_region(3, 3, 0, 0, -1).len(), 9);
     }
 
     #[test]


### PR DESCRIPTION
Replace Nurikabe's integer island-id encoding with boolean sea + per-clue membership, using the existing `active_vertices_connected_2d` / `_region` propagators.  Finite clues are restricted to the open Manhattan ball `dist < n`. The previous encoding remains behind `#[doc(hidden)] solve_nurikabe_with_model` for comparison.

Statistics on a 106-puzzle puzz.link set (release, default Glucose, timeout 120s, same `irrefutable_facts` path as the web solver), the new reachable method is in total **6.92×** faster, with **0 fact mismatches**. 

The only exception is **`94_20x36` instance with ~0.32×**.

- Machine: macOS 15, Apple Silicon (`aarch64-apple-darwin`)
- `rustc` 1.85.1, default C++ Glucose, `cargo run --release`
- Metric: wall-clock of `irrefutable_facts`; speedup = `t_old / t_new`, 2-run best.
- Timeout 120s (subprocess kill)

| Size | n | both finished | avg. speedup | timeout old/new | regressions (>2× slower) |
| --- | --- | --- | --- | --- | --- |
| S (≤100 cells) | 20 | 20 | 5.57× | 0/0 | 0 |
| M | 15 | 15 | 8.23× | 0/0 | 0 |
| L | 28 | 28 | 11.05× | 0/0 | 0 |
| XL | 36 | 36 | 26.47× | 0/0 | 1 (`94_20x36`) |
| XXL | 7 | 1 | 22.58× | 6/1 | 0 |
| **all** | **106** | **100** | **12.71×** | **6/1** | **1** |

The 6 old-encoding XXL timeouts still finish under the new encoding except `1055_40x57` (40×57), where both time out at 120s.

The detailed results are listed below.

```
id                str     w     h  cells  group_id_ms reachable_ms  speedup    agree
------------------------------------------------------------------------------------------------
1017_10x10          S    10    10    100         56.5         12.5    4.51x      yes
1019_10x10          S    10    10    100         66.4         10.1    6.57x      yes
1021_10x10          S    10    10    100         86.1         16.9    5.11x      yes
1023_10x10          S    10    10    100         71.8          8.6    8.38x      yes
140_8x8             S     8     8     64         23.7          3.8    6.18x      yes
146_9x9             S     9     9     81         32.3          6.5    4.94x      yes
188_10x10           S    10    10    100         71.6         11.4    6.31x      yes
198_10x10           S    10    10    100         61.8         10.7    5.79x      yes
238_10x10           S    10    10    100         73.5         10.1    7.28x      yes
314_7x7             S     7     7     49         11.9          4.7    2.52x      yes
334_10x10           S    10    10    100         64.6         11.9    5.43x      yes
352_7x7             S     7     7     49         14.2          3.7    3.89x      yes
37_10x10            S    10    10    100         65.8         10.8    6.10x      yes
402_7x7             S     7     7     49         19.0          8.7    2.20x      yes
471_8x8             S     8     8     64         39.9          5.9    6.73x      yes
663_10x10           S    10    10    100         44.1          8.7    5.07x      yes
672_10x10           S    10    10    100         68.4          9.5    7.22x      yes
854_10x10           S    10    10    100         63.5          8.7    7.34x      yes
942_10x10           S    10    10    100         69.7         11.9    5.84x      yes
962_10x10           S    10    10    100        955.1         91.0   10.50x      yes
1033_15x15          M    15    15    225        394.0         50.1    7.86x      yes
167_10x18           M    18    10    180        223.4         34.0    6.57x      yes
169_10x18           M    18    10    180        324.0         25.3   12.79x      yes
171_10x18           M    18    10    180        237.2         28.1    8.45x      yes
329_9x12            M    12     9    108        114.8         15.1    7.60x      yes
336_10x18           M    18    10    180        226.8         32.8    6.91x      yes
386_15x15           M    15    15    225        547.0         49.0   11.15x      yes
388_15x15           M    15    15    225        544.6         48.7   11.18x      yes
433_12x12           M    12    12    144        147.1         19.8    7.43x      yes
506_10x18           M    18    10    180        217.6         34.0    6.40x      yes
518_11x11           M    11    11    121        135.2         19.3    7.01x      yes
585_10x15           M    15    10    150        229.2         23.0    9.94x      yes
707_12x12           M    12    12    144        167.7         20.4    8.22x      yes
729_13x13           M    13    13    169        211.0         28.6    7.38x      yes
959_11x11           M    11    11    121        119.5         16.4    7.30x      yes
1065_16x16          L    16    16    256        672.5         57.9   11.62x      yes
1103_16x16          L    16    16    256        517.5         66.0    7.84x      yes
152_14x24           L    24    14    336       2092.7         95.7   21.86x      yes
508_17x17           L    17    17    289        726.3         73.5    9.88x      yes
629_17x17           L    17    17    289        538.6         72.8    7.40x      yes
683_14x24           L    24    14    336       3279.4       1226.3    2.67x      yes
689_20x20           L    20    20    400       1781.1        174.7   10.19x      yes
699_17x17           L    17    17    289       1397.8         77.7   17.99x      yes
739_14x24           L    24    14    336       1045.8        104.9    9.97x      yes
823_13x18           L    18    13    234        613.8         48.2   12.75x      yes
850_14x24           L    24    14    336       1291.7         80.7   16.01x      yes
860_14x24           L    24    14    336        959.1         89.9   10.66x      yes
983_14x20           L    20    14    280        639.0         70.7    9.03x      yes
988_14x18           L    18    14    252        608.4         98.8    6.16x      yes
990_14x20           L    20    14    280       1481.3         67.5   21.94x      yes
1045_21x22         XL    22    21    462       3310.9        218.9   15.12x      yes
1046_23x33         XL    33    23    759      30488.9        854.0   35.70x      yes
1047_25x32         XL    32    25    800      25671.9        688.8   37.27x      yes
228_20x36          XL    36    20    720      18228.1        652.6   27.93x      yes
25_20x36           XL    36    20    720      23676.5        512.2   46.23x      yes
261_20x36          XL    36    20    720      17045.0        470.0   36.27x      yes
350_20x36          XL    36    20    720      25158.5        563.6   44.64x      yes
459_20x36          XL    36    20    720      43179.1        921.2   46.87x      yes
460_20x36          XL    36    20    720      34244.6       1362.3   25.14x      yes
510_20x36          XL    36    20    720      22078.7        807.9   27.33x      yes
670_20x36          XL    36    20    720      14575.9       1799.9    8.10x      yes
720_22x23          XL    23    22    506       3092.6        232.6   13.29x      yes
91_20x36           XL    36    20    720      37117.2        733.1   50.63x      yes
92_20x36           XL    36    20    720      20297.3        446.5   45.46x      yes
93_20x36           XL    36    20    720      23232.3        459.5   50.56x      yes
94_20x36           XL    36    20    720      23263.1      73762.6    0.32x      yes
1030_32x32        XXL    32    32   1024      timeout      30486.3        -        -
1055_40x57        XXL    57    40   2280      timeout      timeout        -        -
229_31x45         XXL    45    31   1395      timeout       1639.8        -        -
262_30x36         XXL    36    30   1080      26903.4       1191.3   22.58x      yes
570_31x45         XXL    45    31   1395      timeout       2890.1        -        -
680_31x45         XXL    45    31   1395      timeout       5178.6        -        -
690_50x50         XXL    50    50   2500      timeout      17197.9        -        -
nurikabe0671        L    21    15    315       2273.7        117.7   19.32x      yes
nurikabe1545        L    22    15    330       3020.0         98.9   30.55x      yes
nurikabe1547        L    20    16    320        936.7        104.8    8.94x      yes
nurikabe1553        L    20    15    300       1158.3         92.1   12.58x      yes
nurikabe1567        L    17    20    340       1108.2        311.2    3.56x      yes
nurikabe1575        L    25    15    375       3904.1       1551.4    2.52x      yes
nurikabe1944        L    20    16    320       3045.7        254.8   11.95x      yes
nurikabe1995       XL    29    20    580      12511.6        378.6   33.05x      yes
nurikabe1996       XL    29    20    580      12229.6        373.9   32.71x      yes
nurikabe1998       XL    28    20    560      15030.0        470.7   31.93x      yes
nurikabe2001        L    21    15    315       1820.7         82.1   22.18x      yes
nurikabe2005        L    21    15    315       1688.6         97.1   17.40x      yes
nurikabe2068       XL    29    20    580      13946.2        344.7   40.46x      yes
nurikabe2069       XL    28    20    560      13948.1        278.5   50.09x      yes
nurikabe2070       XL    26    18    468       7472.6        277.0   26.97x      yes
nurikabe2071       XL    26    18    468       7331.8        207.2   35.38x      yes
nurikabe2072        L    20    20    400       4934.8        137.6   35.87x      yes
nurikabe2165       XL    29    20    580       9569.4        291.8   32.79x      yes
nurikabe2167       XL    26    18    468       6130.2        190.8   32.12x      yes
nurikabe2199       XL    30    19    570      25827.0        505.5   51.09x      yes
nurikabe2201       XL    30    19    570      13991.2        749.4   18.67x      yes
nurikabe2238       XL    29    20    580      19874.9        304.5   65.27x      yes
nurikabe2246        L    20    17    340       2847.2        109.7   25.95x      yes
nurikabe2263       XL    30    19    570      17511.4        368.1   47.57x      yes
nurikabe2265       XL    28    20    560      12316.3       2040.8    6.03x      yes
nurikabe2267       XL    29    20    580      13128.0        327.1   40.14x      yes
nurikabe2268       XL    29    20    580      10294.8        565.5   18.21x      yes
nurikabe2269       XL    28    20    560      14059.0       1993.1    7.05x      yes
nurikabe2270        L    21    16    336       1667.5       1100.9    1.51x      yes
nurikabe2281       XL    30    20    600      24616.6        322.5   76.33x      yes
nurikabe2284        L    21    16    336       2358.7        105.3   22.39x      yes
nurikabe2285       XL    30    20    600      16992.2        354.2   47.98x      yes
nurikabe2286       XL    26    18    468       4327.7        333.5   12.98x      yes
------------------------------------------------------------------------------------------------
```

Here are some benchmark instances:

92_20x36:

```
https://puzz.link/p?nurikabe/36/20/q3n4i4i7zr4i5hai4g3n-10k3g1s2n3zo5scn2h3q1g4s3h5zi6j3r3i1n4zp5l3m2j4qem3o7i1m4h4n2x7i2mcp2k1h3g8zk9t4m2k3h5z4v1y7q3k2g3y4w3m4l3g4l3z1h8p3g-18v6zg3h3o5j3n2i5
```

229_31x45

```
https://puzz.link/p?nurikabe/45/31/g4i2i7j3m5r3i5m3i3i5j4m2n4g3i4j5zh6j9j2r5v4i4j4zv6o7w8n3i2r4o3o3l2kew3h4j3o4x3n4k4o2x4l7r4h4zm2m3j3j5h4o3i4v4t5m3k4j9y2o3s9y3g2m5m4j4k2n9h5h4r4i3h2h3m3i3h3h3p3j3i5q4k2r5i2z5i4v3n5w2n6x3m2h3u9zh4g6h3zl2h4n6zq5h4x3o6j3u2p3g5n5h4h5k5m5g4i3l4l3i9q6j2h3m6s3x4zg2l3s4m3i4r5l3n2j3k2k2h9x5l2y7i3t6r4j2r5i2i3i4l6l4j3v6k2i5l5h
```

94_20x36 (the bad case)

```
https://puzz.link/p?nurikabe/36/20/g5g2k4o4k4m6zl4pah1l2q2o2y2o7y3g4l4u5zzzi7h1m8y3zqen3j2h9y-13h3sfo3m-1azo4lfkat1v8h5xczzu3i8i5g4i4zzzkbg8zg8p2p3i4k3g4n9n7i4l9zh
```

nurikabe2246

```
https://puzz.link/p?nurikabe/20/17/g5l5h2r4h7k2j5z4m5zu3m6j9n4g6x6r7z4q7l5l3m4r5q4hai4z3g4k2n5zp3l5n2l6g
```

nurikabe2284

```
https://puzz.link/p?nurikabe/21/16/t2h5h3lbzo6l-10u3n6t-104n6zi3k8j5m5i4r3gazi2zj5o4i6j4zzl1h6k5man5x
```


